### PR TITLE
Remove an unused JS file

### DIFF
--- a/about.html
+++ b/about.html
@@ -189,7 +189,6 @@
 
   <script type="text/javascript" src="js/jquery-3.4.1.min.js"></script>
   <script type="text/javascript" src="js/bootstrap.js"></script>
-  <script type="text/javascript" src="js/custom.js"></script>
 
 
 </body>

--- a/index.html
+++ b/index.html
@@ -465,7 +465,6 @@ Dost is a Student-Led organization established in 2023 by three high school juni
 
   <script type="text/javascript" src="js/jquery-3.4.1.min.js"></script>
   <script type="text/javascript" src="js/bootstrap.js"></script>
-  <script type="text/javascript" src="js/custom.js"></script>
 
 </body>
 

--- a/js/custom.js
+++ b/js/custom.js
@@ -1,8 +1,0 @@
-// to get current year
-function getYear() {
-    var currentDate = new Date();
-    var currentYear = currentDate.getFullYear();
-    document.querySelector("#displayYear").innerHTML = currentYear;
-}
-
-getYear();

--- a/service.html
+++ b/service.html
@@ -251,7 +251,6 @@
 
   <script type="text/javascript" src="js/jquery-3.4.1.min.js"></script>
   <script type="text/javascript" src="js/bootstrap.js"></script>
-  <script type="text/javascript" src="js/custom.js"></script>
 
 </body>
 


### PR DESCRIPTION
The file `custom.js` wasn't used anywhere in the website, and it caused an error while loading pages because there is no tag with the ID `#displayYear`. Deleting it should improve the performance and stability.